### PR TITLE
Add support for inline SVG favicons

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ async function handleRequest(request) {
     return new Response(favicon)
   }
 
+  if (favicon.startsWith('data:image/svg+xml')) return new Response(favicon)
+
   const icon = await fetch(favicon)
   return icon
 }


### PR DESCRIPTION
This adds support to inline SVG favicons which all modern browsers support. Not sure if we should strip `data:image/svg+xml,` from the response. Here is an example - `https://sparkling-feather-61cd.aravindballa.workers.dev/?url=000458870.codepen.website/`

https://twitter.com/LeaVerou/status/1241619866475474946
https://css-tricks.com/emojis-as-favicons/
